### PR TITLE
Remove unnecessary 'hosts' declaration from Ansible task files

### DIFF
--- a/ansible-home-automation/playbooks/roles/common/tasks/main.yml
+++ b/ansible-home-automation/playbooks/roles/common/tasks/main.yml
@@ -1,3 +1,2 @@
 ﻿- name: Placeholder for common tasks
-  hosts: all
   tasks: []

--- a/ansible-home-automation/playbooks/roles/firewall/tasks/main.yml
+++ b/ansible-home-automation/playbooks/roles/firewall/tasks/main.yml
@@ -1,3 +1,2 @@
 ﻿- name: Placeholder for firewall tasks
-  hosts: all
   tasks: []

--- a/ansible-home-automation/playbooks/roles/homeassistant/tasks/main.yml
+++ b/ansible-home-automation/playbooks/roles/homeassistant/tasks/main.yml
@@ -1,3 +1,2 @@
 ﻿- name: Placeholder for homeassistant tasks
-  hosts: all
   tasks: []

--- a/ansible-home-automation/playbooks/roles/sonos_optimization/tasks/main.yml
+++ b/ansible-home-automation/playbooks/roles/sonos_optimization/tasks/main.yml
@@ -1,3 +1,2 @@
 ﻿- name: Placeholder for sonos_optimization tasks
-  hosts: all
   tasks: []

--- a/ansible-home-automation/playbooks/roles/updates/tasks/main.yml
+++ b/ansible-home-automation/playbooks/roles/updates/tasks/main.yml
@@ -1,3 +1,2 @@
 ﻿- name: Placeholder for updates tasks
-  hosts: all
   tasks: []


### PR DESCRIPTION
Eliminate redundant 'hosts' declarations in task files across multiple Ansible roles to streamline configuration.