### PR TITLE
Add step to install Python dependencies for Windows in deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install Python dependencies for Windows
+        run: pip install pywinrm
+
+
       - name: Mask Ansible Secrets
         run: |
           echo "::add-mask::${{ secrets.ANSIBLE_WYSE_PASSWORD }}"


### PR DESCRIPTION
Include a step in the deployment workflow to install the `pywinrm` Python package for Windows environments.