### PR TITLE
Change deployment workflow to use self-hosted runner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   ansible_deploy:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Update the deployment workflow to utilize a self-hosted runner instead of the default Ubuntu environment.