### PR TITLE
Update Windows inventory configuration for localhost and NTLM authentication

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,6 @@ jobs:
             export ansible_wyse_host="${{ secrets.ANSIBLE_WYSE_HOST }}"
             export ansible_wyse_user="${{ secrets.ANSIBLE_WYSE_USER }}"
             export ansible_wyse_password="${{ secrets.ANSIBLE_WYSE_PASSWORD }}"
-            export ansible_windows_host="${{ secrets.ANSIBLE_WINDOWS_HOST }}"
             export ansible_windows_user="${{ secrets.ANSIBLE_WINDOWS_USER }}"
             export ansible_windows_password="${{ secrets.ANSIBLE_WINDOWS_PASSWORD }}"
             envsubst < inventory.ini.j2 > inventory.ini

--- a/ansible-home-automation/inventory.ini.j2
+++ b/ansible-home-automation/inventory.ini.j2
@@ -2,4 +2,4 @@
 teaba-one ansible_host=$ansible_wyse_host ansible_user=$ansible_wyse_user ansible_password=$ansible_wyse_password ansible_connection=ssh
 
 [windows]
-win11 ansible_host=$ansible_windows_host ansible_user=$ansible_windows_user ansible_password=$ansible_windows_password ansible_connection=winrm ansible_winrm_transport=basic ansible_winrm_server_cert_validation=ignore
+localhost ansible_user=$ansible_windows_user ansible_password=$ansible_windows_password ansible_connection=winrm ansible_winrm_transport=ntlm ansible_winrm_server_cert_validation=ignore


### PR DESCRIPTION
Change the Windows inventory configuration to connect using localhost and NTLM authentication instead of WinRM with basic authentication.