### PR TITLE
Add ansible_port configuration for Windows localhost connection

### DIFF
--- a/ansible-home-automation/inventory.ini.j2
+++ b/ansible-home-automation/inventory.ini.j2
@@ -2,4 +2,4 @@
 teaba-one ansible_host=$ansible_wyse_host ansible_user=$ansible_wyse_user ansible_password=$ansible_wyse_password ansible_connection=ssh
 
 [windows]
-localhost ansible_user=$ansible_windows_user ansible_password=$ansible_windows_password ansible_connection=winrm ansible_winrm_transport=ntlm ansible_winrm_server_cert_validation=ignore
+localhost ansible_user=$ansible_windows_user ansible_password=$ansible_windows_password ansible_connection=winrm ansible_winrm_transport=ntlm ansible_winrm_server_cert_validation=ignore ansible_port=5985


### PR DESCRIPTION
Introduce the `ansible_port` configuration for the Windows localhost connection to specify the port used for WinRM communication.