### PR TITLE
Add ansible_windows_host variable to deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,7 @@ jobs:
             export ansible_wyse_password="${{ secrets.ANSIBLE_WYSE_PASSWORD }}"
             export ansible_windows_user="${{ secrets.ANSIBLE_WINDOWS_USER }}"
             export ansible_windows_password="${{ secrets.ANSIBLE_WINDOWS_PASSWORD }}"
+            export ansible_windows_host="${{ secrets.ANSIBLE_WINDOWS_HOST }}"
             envsubst < inventory.ini.j2 > inventory.ini
             cat inventory.ini  # Verify contents
 

--- a/ansible-home-automation/inventory.ini.j2
+++ b/ansible-home-automation/inventory.ini.j2
@@ -2,4 +2,4 @@
 teaba-one ansible_host=$ansible_wyse_host ansible_user=$ansible_wyse_user ansible_password=$ansible_wyse_password ansible_connection=ssh
 
 [windows]
-localhost ansible_user=$ansible_windows_user ansible_password=$ansible_windows_password ansible_connection=winrm ansible_winrm_transport=ntlm ansible_winrm_server_cert_validation=ignore ansible_port=5985
+ansible_host=$ansible_windows_host ansible_user=$ansible_windows_user ansible_password=$ansible_windows_password ansible_connection=winrm ansible_winrm_transport=ntlm ansible_winrm_server_cert_validation=ignore ansible_port=5985


### PR DESCRIPTION
Introduce the `ansible_windows_host` variable to the deployment workflow and update the inventory template accordingly.