### PR TITLE
Update Windows inventory to use static IP for ansible_host

### DIFF
--- a/ansible-home-automation/inventory.ini.j2
+++ b/ansible-home-automation/inventory.ini.j2
@@ -2,4 +2,4 @@
 teaba-one ansible_host=$ansible_wyse_host ansible_user=$ansible_wyse_user ansible_password=$ansible_wyse_password ansible_connection=ssh
 
 [windows]
-ansible_host=$ansible_windows_host ansible_user=$ansible_windows_user ansible_password=$ansible_windows_password ansible_connection=winrm ansible_winrm_transport=ntlm ansible_winrm_server_cert_validation=ignore ansible_port=5985
+192.168.50.169 ansible_user=teaba ansible_password=$ansible_windows_password ansible_connection=winrm ansible_winrm_transport=ntlm ansible_winrm_server_cert_validation=ignore ansible_port=5985


### PR DESCRIPTION
Change the Windows inventory configuration to utilize a static IP address for the ansible_host instead of a variable.