### PR TITLE
Configure roles_path in ansible.cfg for role management

### DIFF
--- a/ansible-home-automation/ansible.cfg
+++ b/ansible-home-automation/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path = ./roles


### PR DESCRIPTION
Set the roles_path in ansible.cfg to streamline role management within the project.